### PR TITLE
Python 3 compatibility and minor bug fix

### DIFF
--- a/moment/core.py
+++ b/moment/core.py
@@ -98,7 +98,9 @@ class Moment(MutableDate):
 
     def clone(self):
         """Return a clone of the current moment."""
-        return Moment(self._date)
+        c = Moment(self._date)
+        c._formula = self._formula
+        return c
 
     def copy(self):
         """Same as clone."""

--- a/moment/date.py
+++ b/moment/date.py
@@ -2,9 +2,11 @@
 Where the magic happens.
 """
 
+import sys
 import calendar
 from datetime import datetime, timedelta
 
+iteritems = (lambda k: iter(k.items())) if sys.version[0] == '3' else (lambda k: k.iteritems())
 
 def add_month(date, number):
     """Add a number of months to a date."""
@@ -35,7 +37,7 @@ class MutableDate(object):
     def add(self, key=None, amount=None, **kwds):
         """Add time to the original moment."""
         if not key and not amount and len(kwds):
-            for k, v in kwds.iteritems():
+            for k, v in iteritems(kwds):
                 self.add(k, v)
         if key == 'years' or key == 'year':
             self._date = add_month(self._date, amount * 12)
@@ -64,7 +66,7 @@ class MutableDate(object):
     def subtract(self, key=None, amount=None, **kwds):
         """Subtract time from the original moment."""
         if not key and not amount and len(kwds):
-            for k, v in kwds.iteritems():
+            for k, v in iteritems(kwds):
                 self.subtract(k, v)
         if key == 'years' or key == 'year':
             self._date = subtract_month(self._date, amount * 12)
@@ -88,7 +90,7 @@ class MutableDate(object):
 
     def replace(self, **kwds):
         """A Pythonic way to replace various date attributes."""
-        for key, value in kwds.iteritems():
+        for key, value in iteritems(kwds):
             if key == 'years' or key == 'year':
                 self._date = self._date.replace(year=value)
             elif key == 'months' or key == 'month':

--- a/moment/parse.py
+++ b/moment/parse.py
@@ -1,5 +1,7 @@
+import sys
 from datetime import datetime
 
+STRING_TYPES = (str,) if sys.version[0] == '3' else (basestring,)
 
 def parse_date_and_formula(*args):
     """Doesn't need to be part of core Moment class."""
@@ -13,7 +15,7 @@ def parse_date_and_formula(*args):
             # Python datetime needs the month and day, too.
             date = [date[0], 1, 1]
         date = datetime(*date)
-    elif isinstance(date, str) or isinstance(date, unicode):
+    elif isinstance(date, STRING_TYPES):
         if formula is None:
             formula = "%Y-%m-%d"
         date = datetime.strptime(date, formula)

--- a/tests.py
+++ b/tests.py
@@ -83,6 +83,10 @@ class SimpleAPI(TestCase):
         d = moment.date(2012, 12, 18, 1, 2, 3)
         self.assertEquals(d.zero.date, datetime(2012, 12, 18))
 
+    # test that repr(moment.now().clone()) does not cause an error
+    def test_now_clone_repr_error(self):
+        repr(moment.now().clone())
+
 
 class Replacement(TestCase):
 


### PR DESCRIPTION
Hi Zach, thanks for the great library. Here is a very quick Python 3 compatibility patch (I would've used six but I didn't know whether you would be down with adding it as a dependency, let me know). 

I also noticed that repr(moment.now.clone()) results in an error. I changed the clone method to copy _formula as well which seems like the right thing to do but I haven't looked extensively at the library so I'm not sure.