### PR TITLE
Fix the command used to install requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
   - "2.7"
-install: pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
 script: python tests.py


### PR DESCRIPTION
On master, Travis fails with `no such option: --use-mirrors` (see https://travis-ci.org/zachwill/moment/builds/170556631).
