### PR TITLE
Duckling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,35 @@ moment.utcnow().weekday
 # And, there's an easy way to zero out the hours, minutes, and seconds
 moment.utcnow().zero
 ```
+
+Optional: Use [duckling](https://github.com/facebook/duckling)
+--------
+
+- [Duckling](https://github.com/facebook/duckling) is a library from Facebook to parse text (time expressions and others) into structured data.
+
+- It is a Haskell library, so to use this you ll need a duckling server running on 0.0.0.0:8000 ([see the installation instructions](https://github.com/facebook/duckling#quickstart))
+
+- Integrating with duckling allows to parse fairly complex time expressions such as `day after tomorrow`, `next Saturday` that are not covered by moment atm.
+
+- However, this is completely optional, this behavior only triggers if moment fails to get the date (returns None) and duckling is installed. Else reverts back to the usual moment output.        
+
+With duckling:
+
+```python
+>>> moment.date('day after tomorrow')
+<Moment(2018-09-12T00:00:00)>
+>>> moment.date('next saturday')
+<Moment(2018-09-15T00:00:00)>
+>>> 
+
+```
+
+W/o duckling:
+
+```python
+>>> import moment
+>>> moment.date('day after tomorrow')
+<Moment>
+>>> moment.date('next saturday')
+<Moment>
+```

--- a/moment/__init__.py
+++ b/moment/__init__.py
@@ -1,2 +1,3 @@
 from .api import *
 from .core import Moment
+from .ducklingparser import DucklingDateParser

--- a/moment/ducklingparser.py
+++ b/moment/ducklingparser.py
@@ -1,0 +1,46 @@
+import requests
+import dateparser
+
+MAX_RETRIES = 5
+
+
+def POST(api, **kwargs):
+    for x in range(MAX_RETRIES):
+        try:
+            r = requests.post(api, **kwargs)
+            if r.ok:
+                return r
+        except Exception as e:
+            pass
+    return None
+
+
+class DucklingDateParser(object):
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host', '0.0.0.0')
+        self.port = kwargs.get('port', '8000')
+
+    def parse(self, date, **kwargs):
+        data = {
+            'locale': 'en_GB',
+            'text': date
+        }
+
+        duck_api = "http://{}:{}/parse".format(self.host, self.port)
+        r = POST(duck_api, data=data)
+        if r is None:
+            return None
+        return self._format_date(r.json(), **kwargs)
+
+    @staticmethod
+    def _format_date(response, **kwargs):
+        try:
+            result = response[0]
+            _date = result['value']['value']
+            return dateparser.parse(_date, **kwargs)
+        except (IndexError, KeyError):
+            return None
+
+
+
+

--- a/moment/parse.py
+++ b/moment/parse.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
 import dateparser
+from .ducklingparser import DucklingDateParser
 
 from .utils import STRING_TYPES
 
 
-def parse_date_and_formula(*args):
+def parse_date_and_formula(*args, **kwargs):
     """Doesn't need to be part of core Moment class."""
     date, formula = _parse_arguments(*args)
     parse_settings = {"PREFER_DAY_OF_MONTH": "first"}
@@ -21,8 +22,11 @@ def parse_date_and_formula(*args):
             date = [date[0], 1, 1]
         date = datetime(*date)
     elif isinstance(date, STRING_TYPES):
+        _date = date
         date = dateparser.parse(date, settings=parse_settings)
         formula= "%Y-%m-%dT%H:%M:%S"
+        if date is None:  # try parsing the date with duckling (https://github.com/facebook/duckling)
+            date = DucklingDateParser(**kwargs).parse(_date, date_formats=[formula], settings=parse_settings)
     return date, formula
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytz>=2017.2
 times
+requests

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name="moment",
-    version="0.8.1",
+    version="0.8.2",
     url="http://github.com/zachwill/moment",
     author="Zach Williams",
     author_email="hey@zachwill.com",


### PR DESCRIPTION
- [Duckling](https://github.com/facebook/duckling) is a library from Facebook to parse text (time expressions and others) into structured data.

- It is a Haskell library, so to use this you ll need a duckling server running on 0.0.0.0:8000 ([see the installation instructions](https://github.com/facebook/duckling#quickstart))

- Integrating with duckling allows to parse fairly complex time expressions such as `day after tomorrow`, `next Saturday` that are not covered by moment atm.

- However, this is completely optional, this behavior only triggers if moment fails to get the date (returns None) and duckling is installed. Else reverts back to the usual moment output.        

With duckling:

```python
>>> moment.date('day after tomorrow')
<Moment(2018-09-12T00:00:00)>
>>> moment.date('next saturday')
<Moment(2018-09-15T00:00:00)>
>>> 

```

W/o duckling:

```python
>>> import moment
>>> moment.date('day after tomorrow')
<Moment>
>>> moment.date('next saturday')
<Moment>
```