### PR TITLE
Fix for Windows

### DIFF
--- a/moment/core.py
+++ b/moment/core.py
@@ -49,7 +49,7 @@ class Moment(MutableDate):
         try:
             # Seconds since epoch
             date = func(timestamp)
-        except ValueError:
+        except (ValueError, OSError):
             # Milliseconds since epoch
             date = func(timestamp / 1000)
         # Feel like it's crazy this isn't default, but whatever.


### PR DESCRIPTION
Hi,

When trying to convert a string timestamp to a Moment object in python on Windows, we get an error if the timestamps is in milliseconds.

ex:
``` python
moment.unix(100000000000)
```
Result:
```
OSError: [Errno 22] Invalid argument
```

Adding except for OSError let the execution follow in the intended way